### PR TITLE
feat: dev-nav-tab with example pages in app/pages

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
-import { Tabs } from "expo-router";
 import { Image } from "expo-image";
+import { Tabs } from "expo-router";
 import { StyleSheet } from "react-native";
 
 const listIcon = require("@/assets/images/shopping-list.png");

--- a/app/(tabs)/dev.tsx
+++ b/app/(tabs)/dev.tsx
@@ -1,0 +1,66 @@
+import { useNavigation } from '@react-navigation/native';
+import React from 'react';
+import { Alert, Button, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+const PAGES = [
+    // Adjust these entries to match the route names you registered in your root/layout navigator.
+    { label: 'Demo Page', route: 'pages/demo' },
+    { label: 'Dummy Login Page', route: 'pages/dummylogin' },
+    // Add more pages here as you create them, e.g.
+    // { label: 'Some Page', route: 'SomePage' },
+];
+
+export default function DevTab() {
+    const navigation = useNavigation();
+
+    function goTo(route: string) {
+        try {
+            // Try navigating; if the route isn't registered this will typically throw or do nothing.
+            // Cast to any to avoid strict typing issues with different navigator types.
+            (navigation as any).navigate(route);
+        } catch (err) {
+            Alert.alert('Navigation error', `Could not navigate to "${route}".\n\n${String(err)}`);
+        }
+    }
+
+    return (
+        <ScrollView contentContainerStyle={styles.container}>
+            <Text style={styles.header}>Dev: Pages</Text>
+            <Text style={styles.note}>This is a DEV page, meant to help demo different pages that do not have natural navigation implemented within the app/pages folder</Text>
+
+            {PAGES.map((p) => (
+                <View key={p.route} style={styles.item}>
+                    <Button title={p.label} onPress={() => goTo(p.route)} />
+                </View>
+            ))}
+
+            <View style={styles.note}>
+                <Text style={styles.noteText}>
+                    Tip: Ensure the route names above match the names you registered in your root navigator
+                    (app/_layout.tsx). If a route is not registered you will see an alert.
+                </Text>
+            </View>
+        </ScrollView>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 16,
+    },
+    header: {
+        fontSize: 18,
+        marginBottom: 12,
+        fontWeight: '600',
+    },
+    item: {
+        marginBottom: 10,
+    },
+    note: {
+        marginTop: 20,
+        marginBottom: 10
+    },
+    noteText: {
+        color: '#666',
+    },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,0 +1,11 @@
+import { Stack } from 'expo-router';
+import React from 'react';
+// ...existing code...
+export default function RootLayout(): React.ReactElement {
+  return (
+    <Stack>
+      {/* Render the (tabs) group as the default/main area */}
+      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+    </Stack>
+  );
+}

--- a/app/pages/demo.tsx
+++ b/app/pages/demo.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function DemoPage() {
+	return (
+		<View style={styles.container}>
+			<Text style={styles.title}>Demo Navigation Page</Text>
+			<Text style={styles.subtitle}>If you found this page, the dev navigator is working! Yay!</Text>
+			<Text style={styles.notice}>You can go back with the top left arrow</Text>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	container: {
+		padding: 20,
+		justifyContent: 'center',
+		alignItems: 'center',
+		backgroundColor: '#2196f3',
+	},
+	title: {
+		fontSize: 20,
+		fontWeight: '600',
+		marginBottom: 8,
+		color: '#fff',
+	},
+	subtitle: {
+		fontSize: 14,
+		color: '#fff',
+		textAlign: 'center',
+	},
+	notice: {
+		color: 'yellow',
+		fontWeight: 'bold'
+	}
+});

--- a/app/pages/dummylogin.tsx
+++ b/app/pages/dummylogin.tsx
@@ -1,0 +1,11 @@
+import { Text, View } from 'react-native';
+
+export default function DummyLogin() {
+
+	return (
+		<View>
+			<Text>Dummy Login Page</Text>
+            <Text>This is just another example for dev navigation</Text>
+		</View>
+	);
+};


### PR DESCRIPTION
This commit is focused on a new "DEV" tab that, for the duration of our production, will be helpful in navigating to pages that don't have natural navigation setup.